### PR TITLE
Aether Portal Minor Tweaks

### DIFF
--- a/config/randomportals/portal_types/aether_portal/0.json
+++ b/config/randomportals/portal_types/aether_portal/0.json
@@ -25,7 +25,7 @@
 			{
 				"registryName": "minecraft:glowstone",
 				"meta": 32767,
-				"minimumAmount": 0
+				"minimumAmount": 10
 			}
 		],
 		"requiredCorner": "ANY",
@@ -42,7 +42,9 @@
 		],
 		"activatorConsumeBehavior": "DO_NOTHING",
 		"spawnFireBeforeActivating": false,
-		"activationSounds": []
+		"activationSounds": [
+			"minecraft.entity.lightning_bolt.thunder"
+		]
 	},
 	"color": {
 		"colors": [


### PR DESCRIPTION
Set minimum glowstone amount for a successful portal to 10 blocks and added unique sound effect to opening (lightning strike).