### PR TITLE
less annoying music when exploring around rivers

### DIFF
--- a/ambience_music/ambience.properties
+++ b/ambience_music/ambience.properties
@@ -14,12 +14,12 @@ event.boss=Ruthless
 event.underground=IntoSilenceP1,Underground1,Underground2,Underground3,Underground4,Underground5,Underground6,Underground7,Underground8,Underground9,Underground10,Underground11
 event.deepUnderground=DeepUnder1,DeepUnder2,DeepUnder3
 event.village=ACelticTale,CircleOfLife,VillageDay1,VillageDay2
-event.underwater=Eventide
 event.night=IntoSilenceP1,Moonsong,CrystalForest,Alvae,Storm,FallOfTheLeaf,IntoSilenceP2,OdeToTheFallen,Sleeper,Night1,Night2,FarBeyond
 event.rain=Moonsong,KeeperOfTheForest,IntoSilenceP1,CrystalForest,FrozenInTime
 event.horde=InvasionSong
 event.highUp=ElytraFlight
 event.generic=ACelticTale,Alpha,ASongFromTheDeep,BeautifulDreams,CelticLore,Deliverance,IntoTheUnknown,KeeperOfTheForest,KingdomOfBards,Mourning,NeverToReturn,OdeToTheFallen,Reverie,SacredEarth,WoodlandTales,WhereIBelong,WhatLiesBeyond,Wanderer,Mirrormere,NightAtTheEolian,WildfireP1,WildfireP2,CrannNaBeatha,CastleInTheSky,NightoftheFae
+event.underwater=Eventide
 
 event.fortress=NFortress1,NFortress2,NFortress3
 event.stronghold=Fort1,Fort2,Fort3,Fort4,Fort5


### PR DESCRIPTION
When you explore, if you go underwater, the music cuts out in favor of the underwater music. If you stay there for more than a second or two, when you come back out of the water, an entirely different music plays. It gets really annoying for players who cross rivers frequently.

What I did was put the underwater music at lower priority than the generic music. There's probably a better fix though.