### PR TITLE
Disable Team's chat bubbles

### DIFF
--- a/src/common/config/teamsmod.cfg
+++ b/src/common/config/teamsmod.cfg
@@ -4,7 +4,7 @@ general {
 
     client {
         # Disables chat bubbles from rendering
-        B:disableChatBubble=false
+        B:disableChatBubble=true
 
         # Disables compass overlay from rendering
         B:disableCompassOverlay=false


### PR DESCRIPTION
Currently on servers, two chat bubbles appear over players' heads. One from Dynamic Surroundings and one from the Teams mod. I disabled the Teams chat bubbles here since DS is what RotN has used in the past. Feel free to use Teams instead, though, or disable chat bubbles altogether.