### PR TITLE
Edits to some keybindings

### DIFF
--- a/config/defaultoptions/keybindings.txt
+++ b/config/defaultoptions/keybindings.txt
@@ -146,7 +146,7 @@ key_key.toolbelt.cycle.right:0
 key_key.trashslot.toggle:0
 key_key.trashslot.delete:211
 key_key.trashslot.deleteAll:0
-key_Eatkey:0
+key_Eatkey:-99
 key_Spitkey:0
 key_key.craftingcraft.back_to_inventory:0
 key_key.fullscreenwindowed.unused:0

--- a/config/defaultoptions/keybindings.txt
+++ b/config/defaultoptions/keybindings.txt
@@ -33,7 +33,7 @@ key_key.hotbar.8:9
 key_key.hotbar.9:10
 key_of.key.zoom:46
 key_keybind.baublesinventory:0
-key_Options.Reload:25
+key_Options.Reload:0
 key_Force Play:24
 key_Options.Shortcut1:0
 key_Options.Shortcut2:0
@@ -95,7 +95,7 @@ key_key.jei.nextPage:209
 key_key.jei.bookmark:30
 key_key.jei.toggleBookmarkOverlay:0
 key_key.aquaacrobatics.toggle_crawling:44
-key_key.betterHud.open:40
+key_key.betterHud.open:0
 key_key.carry.desc:42
 key_key.clienttweaks.disable_step_assist:0
 key_key.clienttweaks.hide_offhand_item:0
@@ -113,7 +113,7 @@ key_dsurround.cfg.keybind.AnimaniaBadges:0
 key_key.elenaidodge.dodge:56
 key_key.mod_lavacow.special:34
 key_FpsReducer.key.guiOpen:0
-key_FpsReducer.key.forceIdle:197
+key_FpsReducer.key.forceIdle:0
 key_waila.keybind.wailaconfig:0
 key_waila.keybind.wailadisplay:0
 key_waila.keybind.liquid:0
@@ -136,17 +136,17 @@ key_Camera up:201
 key_Camera down:209
 key_Swap shoulder:64
 key_Toggle perspective:0
-key_teamsmod.keyhud.desc:47
-key_teamsmod.keycompass.desc:50
+key_teamsmod.keyhud.desc:0
+key_teamsmod.keycompass.desc:0
 key_teamsmod.keyaccept.desc:27
 key_teamsmod.keyswitch.desc:19
 key_key.toolbelt.open:41
 key_key.toolbelt.cycle.left:0
 key_key.toolbelt.cycle.right:0
-key_key.trashslot.toggle:20
+key_key.trashslot.toggle:0
 key_key.trashslot.delete:211
 key_key.trashslot.deleteAll:0
-key_Eatkey:19
+key_Eatkey:0
 key_Spitkey:0
 key_key.craftingcraft.back_to_inventory:0
 key_key.fullscreenwindowed.unused:0


### PR DESCRIPTION
I noticed that someone I was playing with accidently pressed a keybind which disabled the Teams HUD and they didn't know what they did. I decided to go through all the keybindings and remove any that might cause conflicts, HUD/UI hiding, or open GUIs.

I don't know if you guys want all of these disabled, so feel free to pick and choose!

Also since it's not clear in the code, `key_Options.Reload` is the Ambience music reload key.