### PR TITLE
Fix resource packs not applying

### DIFF
--- a/config/defaultoptions/options.txt
+++ b/config/defaultoptions/options.txt
@@ -15,7 +15,7 @@ difficulty:2
 fancyGraphics:true
 ao:1
 renderClouds:true
-resourcePacks:["AntiqueAtlasExtra-v1.2.zip","Refreshed Aether.zip","Modern+Pyrotech+[1.12]+[v1.2].zip","Vanilla_Future_Texture_optifine.zip","Modernity-format3-v3.5.2.zip","AnimEmis_InF_SW.zip","Official ROTN tweaks"]
+resourcePacks:["AntiqueAtlasExtra-v1.2.zip","Refreshed Aether.zip","Modern Pyrotech [1.12] [v1.2].zip","Vanilla_Future_Texture_optifine.zip","Modernity-format3-v3.6.0.zip","AnimEmis_InF_SW.zip","Official ROTN tweaks"]
 incompatibleResourcePacks:[]
 lastServer:
 lang:en_us


### PR DESCRIPTION
"Modern Pyrotech [1.12] [v1.2].zip" should have no "+" signs as spaces.

Modernity had the wrong version number. I changed it to the version that is present in the 3.1.1a release, however there are a few updates to the resourcepack after 3.6.0 so it might have to be changed if you guys have a newer version in dev.