### PR TITLE
Fix general item dupe

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -71,7 +71,7 @@ automation {
     B:"Obsidian pressure plate"=true
     B:"Piston Block Breakers"=true
     B:"Pistons Push and Pull Items"=true
-    B:"Pistons move t es"=true
+    B:"Pistons move t es"=false
     B:"Rain detector"=false
     B:"Redstone inductor"=true
     B:"Redstone randomizer"=true


### PR DESCRIPTION
Disabled quark tile entity move allowing duping of chest contents.