### PR TITLE
Mourner (Scarlite > E.Ruby)

### DIFF
--- a/scripts/mobLootTables.zs
+++ b/scripts/mobLootTables.zs
@@ -397,6 +397,11 @@ val scarecrow = LootTweaker.getTable("mod_lavacow:scarecrow");
 val night_shard = scarecrow.addPool("night_shard", 0, 1, 2, 9);
 night_shard.addItemEntry(<contenttweaker:shard_of_night>, 1, 1, [Functions.setCount(0, 1), Functions.lootingEnchantBonus(0, 1, 64)], []);
 
+// Defiled Lands' Mourner'
+LootTable.removeGlobalItem("defiledlands:scarlite"); // Can't get removeEntry to work so this is a workaround - not permanent!
+val lootMourner = LootTweaker.getTable("defiledlands:entities/the_mourner");
+val lmournerMain = lootMourner.getPool("the_mourner");
+lmournerMain.addItemEntry(<contenttweaker:earthen_ruby>, 1, 1, [Functions.setCount(4, 8)], []);
 
 // new loot tables must be assigned to entities via spawn.json, within Incontrol's config folder 
 


### PR DESCRIPTION
Replaced The Mourner's Scarlite drops with Earthen Ruby instead, might need to play with drop # (atm it is 4 to 8)

NOTE!!! - Scarlite was not able to be easily removed from The Mourner's loot table, the workaround was to remove it globally as it is currently not being used in any recipes

If that is an issue in the future, it will have to be reverted. To do so, remove line 401 
