### PR TITLE
fix: set AncientBeasts Sandmonster spawn chance to a valid high value

### DIFF
--- a/config/ancientbeasts.cfg
+++ b/config/ancientbeasts.cfg
@@ -100,7 +100,7 @@ general {
     D:"Sandmonster Miniboss Health Bonus"=220.0
 
     # Sandmonster spawn chance 5 is uncommon, 1 is common
-    I:"Sandmonster Spawn"=0
+    I:"Sandmonster Spawn"=1234567890
 
     # this is mostly due to compatibility
     I:"Sandmonster tame stack size"=1024


### PR DESCRIPTION
My server crashed with the following backtrace:
```
Description: Exception ticking world

java.lang.IllegalArgumentException: bound must be positive
    at java.util.Random.nextInt(Random.java:388)
    at com.unoriginal.ancientbeasts.entity.Entities.EntitySandy.getCanSpawnHere(EntitySandy.java:708)
    at net.minecraft.world.WorldEntitySpawner.findChunksForSpawning(WorldEntitySpawner.java:152)
    at net.minecraft.world.WorldServer.tick(WorldServer.java:203)
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:756)
    at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:397)
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Thread.java:750)
```

After some investigation, it turns out that this was because of [this function call](https://github.com/Un-Original1/BeastSlayer/blob/737af48742cb726393122889f9b2dbb912edc7be/src/main/java/com/unoriginal/beastslayer/entity/Entities/EntitySandy.java#L676):

```java
rand.nextInt(BeastSlayerConfig.sandmonsterSpawnChance) == 0
```

`rand.nextInt`'s argument must be greater than 0, but RotN's AncientBeasts configuration specifies that `sandmonsterSpawnChance` is 0, meaning that this line would throw every time it was executed.

This is fixed by setting the spawn chance to approximately 1 in 1 billion instead.