### PR TITLE
Fix issue with 'mystic_cincinnasite_lamp' and 'ferrought_cincinnasite_lamp' blocks (breakable without pickaxe)

### DIFF
--- a/scripts/contentweaker/simpleExtraBlocks.zs
+++ b/scripts/contentweaker/simpleExtraBlocks.zs
@@ -2309,21 +2309,19 @@ coba_star.setFullBlock(false);
 coba_star.setCreativeTab(<creativetab:rotn_blocks>);
 coba_star.register();
 
-var mystic_cincinnasite_lamp = VanillaFactory.createBlock("mystic_cincinnasite_lamp", <blockmaterial:Glass>);
+var mystic_cincinnasite_lamp = VanillaFactory.createBlock("mystic_cincinnasite_lamp", <blockmaterial:Rock>);
 mystic_cincinnasite_lamp.setCreativeTab(<creativetab:rotn_blocks>);
 mystic_cincinnasite_lamp.setLightValue(1.0);
 mystic_cincinnasite_lamp.setBlockSoundType(<soundtype:stone>);
 mystic_cincinnasite_lamp.setBlockHardness(18);
-mystic_cincinnasite_lamp.setBlockMaterial(<blockmaterial:glass>);
 mystic_cincinnasite_lamp.setToolLevel(1);
 mystic_cincinnasite_lamp.register();
 
-var ferrought_cincinnasite_lamp = VanillaFactory.createBlock("ferrought_cincinnasite_lamp", <blockmaterial:Glass>);
+var ferrought_cincinnasite_lamp = VanillaFactory.createBlock("ferrought_cincinnasite_lamp", <blockmaterial:Rock>);
 ferrought_cincinnasite_lamp.setCreativeTab(<creativetab:rotn_blocks>);
 ferrought_cincinnasite_lamp.setLightValue(1.0);
 ferrought_cincinnasite_lamp.setBlockSoundType(<soundtype:stone>);
 ferrought_cincinnasite_lamp.setBlockHardness(38);
-ferrought_cincinnasite_lamp.setBlockMaterial(<blockmaterial:glass>);
 ferrought_cincinnasite_lamp.setToolLevel(2);
 ferrought_cincinnasite_lamp.register();
 


### PR DESCRIPTION
**My reasoning:**

Since standard Cincinnasite Lanterns cannot be broken without a Crude level or above pickaxe, I thought it would make sense for its variants (Mystic and Ferrought) to also not be breakable without a pickaxe, not to mention that they have even higher mining levels (despite not requiring a pickaxe to be broken) than the standard one.

<img width="1525" height="990" alt="standard" src="https://github.com/user-attachments/assets/66e414b6-da44-47ca-8bad-82f9682145e0" />

<img width="1445" height="1075" alt="mystic" src="https://github.com/user-attachments/assets/eb583916-bc65-4468-8ff8-8269dc93667b" />

<img width="1603" height="1009" alt="ferrought" src="https://github.com/user-attachments/assets/6c6dcaa5-8099-4961-98a5-235e052b7faa" />