### PR TITLE
Adding back soup recipes and stock

### DIFF
--- a/scripts/ex_sartagine.zs
+++ b/scripts/ex_sartagine.zs
@@ -432,9 +432,9 @@ val cakeBatter = <betterwithmods:raw_pastry>;
 
 // Stock Recipes
 recipes.remove(stock);
-//ExSartagine.addPotRecipe(<minecraft:bone>|<undergroundbiomes:fossil_piece:2>|<undergroundbiomes:fossil_piece:3>|<undergroundbiomes:fossil_piece:5>|<undergroundbiomes:fossil_piece:7>, stock);
-//ExSartagine.addPotRecipe(veggie, stock*2);
-//ExSartagine.addPotRecipe(<ore:listAllmeatraw>|<betterwithaddons:congealed>, stock*3);
+ExSartagine.addPotRecipe(<minecraft:bone>|<undergroundbiomes:fossil_piece:2>|<undergroundbiomes:fossil_piece:3>|<undergroundbiomes:fossil_piece:5>|<undergroundbiomes:fossil_piece:7>, stock);
+ExSartagine.addPotRecipe(veggie, stock*2);
+ExSartagine.addPotRecipe(<ore:listAllmeatraw>|<betterwithaddons:congealed>, stock*3);
 
 // Wormhole Potion
 ExSartagine.addKettleRecipe([<quark:arrow_ender>,<minecraft:glass_bottle>],null,waterBottle,[<bountifulbaubles:potionwormhole>],300);
@@ -1208,10 +1208,10 @@ RecipeBuilder.get("chef")
 
 //Pumpkin soup
 recipes.removeByRecipeName("harvestcraft:pumpkinsoupitem");
-//stocke ExSartagine.addKettleRecipe([stock,heavyCream,pumpkin],cookKitKettle,null,[<harvestcraft:pumpkinsoupitem>],80);
+ExSartagine.addKettleRecipe([stock,heavyCream,pumpkin],cookKitKettle,null,[<harvestcraft:pumpkinsoupitem>],80);
 // Carrot soup
 recipes.removeByRecipeName("harvestcraft:carrotsoupitem");
-//stocke ExSartagine.addKettleRecipe([stock,heavyCream,carrot],cookKitKettle,null,[<harvestcraft:carrotsoupitem>],80);
+ExSartagine.addKettleRecipe([stock,heavyCream,carrot],cookKitKettle,null,[<harvestcraft:carrotsoupitem>],80);
 //Glassed carrots
 recipes.removeByRecipeName("harvestcraft:glazedcarrotsitem");
 ExSartagine.addKettleRecipe([carrot,butter,sugar],cookKitKettle,null,[<harvestcraft:glazedcarrotsitem>],80);
@@ -1239,7 +1239,7 @@ RecipeBuilder.get("chef")
   .create();
 //Potato Soup
 recipes.removeByRecipeName("harvestcraft:potatosoupitem_dustsalt");
-//stocke ExSartagine.addKettleRecipe([stock,heavyCream,potato],cookKitKettle,null,[<harvestcraft:potatosoupitem>],80);
+ExSartagine.addKettleRecipe([stock,heavyCream,potato],cookKitKettle,null,[<harvestcraft:potatosoupitem>],80);
 //Grilled mushroom
 recipes.removeByRecipeName("harvestcraft:grilledmushroomitem");
 ExSartagine.addWokRecipe([mushroom], [<harvestcraft:grilledmushroomitem>]);
@@ -1257,7 +1257,7 @@ RecipeBuilder.get("chef")
   .create();
 // Chicken noodle soup
 recipes.removeByRecipeName("harvestcraft:chickennoodlesoupitem");
-//stocke ExSartagine.addKettleRecipe([rawChicken,carrot,pasta,stock],cookKitKettle,null,[<harvestcraft:chickennoodlesoupitem>],80);
+ExSartagine.addKettleRecipe([rawChicken,carrot,pasta,stock],cookKitKettle,null,[<harvestcraft:chickennoodlesoupitem>],80);
 // Chicken pot pie
 recipes.removeByRecipeName("harvestcraft:chickenpotpieitem");
 ExSartagine.addKettleRecipe([rawChicken,potato,carrot,dough],cookKitKettle,null,[<harvestcraft:chickenpotpieitem>],80);
@@ -1374,7 +1374,7 @@ RecipeBuilder.get("chef")
   .create();
 //Vegetable soup
 recipes.removeByRecipeName("harvestcraft:vegetablesoupitem");
-//stocke ExSartagine.addKettleRecipe([potato,carrot,mushroom,stock],cookKitKettle,null,[<harvestcraft:vegetablesoupitem>],80);
+ExSartagine.addKettleRecipe([potato,carrot,mushroom,stock],cookKitKettle,null,[<harvestcraft:vegetablesoupitem>],80);
 //Fruit salad -&C
 recipes.removeByRecipeName("harvestcraft:fruitsaladitem");
 recipes.addShapeless("fruit_salad",<harvestcraft:fruitsaladitem>,[fruit,fruit,cookKitBad]);
@@ -1601,7 +1601,7 @@ RecipeBuilder.get("chef")
   .create();
 // Cucumber soup
 recipes.removeByRecipeName("harvestcraft:cucumbersoupitem");
-//stocke ExSartagine.addKettleRecipe([cucumber,stock,heavyCream],cookKitKettle,null,[<harvestcraft:cucumbersoupitem>],80);
+ExSartagine.addKettleRecipe([cucumber,stock,heavyCream],cookKitKettle,null,[<harvestcraft:cucumbersoupitem>],80);
 //Vegetarian lettuce wrap
 recipes.removeByRecipeName("harvestcraft:vegetarianlettucewrapitem");
 recipes.addShapeless("v_lettuce_wrap",<harvestcraft:vegetarianlettucewrapitem>,[cucumber,lettuce,tomato,cookKitBad]);
@@ -1616,7 +1616,7 @@ recipes.removeByRecipeName("harvestcraft:marinatedcucumbersitem");
 ExSartagine.addKettleRecipe([cucumber,onion,sugar,vinegar],cookKitKettle,null,[<harvestcraft:marinatedcucumbersitem>],80);
 //Rice soup
 recipes.removeByRecipeName("harvestcraft:ricesoupitem");
-//stocke ExSartagine.addKettleRecipe([rice,stock],null,null,[<harvestcraft:ricesoupitem>],80);
+ExSartagine.addKettleRecipe([rice,stock],null,null,[<harvestcraft:ricesoupitem>],80);
 //Fried rice
 recipes.removeByRecipeName("harvestcraft:friedriceitem");
 ExSartagine.addKettleRecipe([rice,carrot,egg,onion],cookKitKettle,null,[<harvestcraft:friedriceitem>],80);
@@ -1814,7 +1814,7 @@ RecipeBuilder.get("chef")
   .create();
 // Creamed broccoli soup
 recipes.removeByRecipeName("harvestcraft:creamedbroccolisoupitem");
-//stocke ExSartagine.addKettleRecipe([broccoli,carrot,flour,blackPepper,stock],cookKitKettle,null,[<harvestcraft:creamedbroccolisoupitem>],80);
+ExSartagine.addKettleRecipe([broccoli,carrot,flour,blackPepper,stock],cookKitKettle,null,[<harvestcraft:creamedbroccolisoupitem>],80);
 //Sweet potato pie
 recipes.removeByRecipeName("harvestcraft:sweetpotatopieitem");
 ExSartagine.addKettleRecipe([sweetPotato,dough,groundCinnamon,marshmellows],cookKitKettle,waterBottle,[<harvestcraft:sweetpotatopieitem>],80);
@@ -1829,13 +1829,13 @@ recipes.removeByRecipeName("harvestcraft:steamedpeasitem_dustsalt");
 ExSartagine.addKettleRecipe([peas,salt],null,waterBucket,[<harvestcraft:steamedpeasitem>],80);
 //Split pea soup
 recipes.removeByRecipeName("harvestcraft:splitpeasoupitem");
-//stocke ExSartagine.addKettleRecipe([peas,rawPork,blackPepper,stock],null,null,[<harvestcraft:splitpeasoupitem>],80);
+ExSartagine.addKettleRecipe([peas,rawPork,blackPepper,stock],null,null,[<harvestcraft:splitpeasoupitem>],80);
 //Pineapple ham
 recipes.removeByRecipeName("harvestcraft:pineapplehamitem");
 ExSartagine.addKettleRecipe([pineapple,rawPork,cherry,sugar],cookKitKettle,null,[<harvestcraft:pineapplehamitem>],80);
 //Turnip soup
 recipes.removeByRecipeName("harvestcraft:turnipsoupitem");
-//stocke ExSartagine.addKettleRecipe([turnip,pumpkin,butter,stock],cookKitKettle,null,[<harvestcraft:turnipsoupitem>],80);
+ExSartagine.addKettleRecipe([turnip,pumpkin,butter,stock],cookKitKettle,null,[<harvestcraft:turnipsoupitem>],80);
 //Roasted root veggie medley
 recipes.removeByRecipeName("harvestcraft:roastedrootveggiemedleyitem_cropturnip");
 recipes.removeByRecipeName("harvestcraft:roastedrootveggiemedleyitem_cropsweetpotato");
@@ -1940,7 +1940,7 @@ recipes.removeByRecipeName("harvestcraft:peasandceleryitem");
 ExSartagine.addKettleRecipe([celery,peas,lemon,blackPepper],null,waterBottle,[<harvestcraft:peasandceleryitem>],80);
 // Celery soup
 recipes.removeByRecipeName("harvestcraft:celerysoupitem");
-//stocke ExSartagine.addKettleRecipe([celery,onion,stewCondiment,stock],cookKitKettle,null,[<harvestcraft:celerysoupitem>],80);
+ExSartagine.addKettleRecipe([celery,onion,stewCondiment,stock],cookKitKettle,null,[<harvestcraft:celerysoupitem>],80);
 //Zucchini bread
 recipes.removeByRecipeName("harvestcraft:zucchinibreaditem");
 ExSartagine.addKettleRecipe([zucchini,dough,groundCinnamon,walnut],cookKitKettle,null,[<harvestcraft:zucchinibreaditem>],80);
@@ -1958,7 +1958,7 @@ recipes.removeByRecipeName("harvestcraft:asparagusquicheitem");
 ExSartagine.addKettleRecipe([aSparagus,egg,onion,cheese],cookKitKettle,null,[<harvestcraft:asparagusquicheitem>],80);
 //Asparagus soup
 recipes.removeByRecipeName("harvestcraft:asparagussoupitem");
-//stocke ExSartagine.addKettleRecipe([aSparagus,onion,butter,stock],cookKitKettle,null,[<harvestcraft:asparagussoupitem>],80);
+ExSartagine.addKettleRecipe([aSparagus,onion,butter,stock],cookKitKettle,null,[<harvestcraft:asparagussoupitem>],80);
 //Walnut raisin bread
 recipes.removeByRecipeName("harvestcraft:walnutraisinbreaditem");
 ExSartagine.addKettleRecipe([walnut,<harvestcraft:raisinsitem>,dough,groundCinnamon],cookKitKettle,null,[<harvestcraft:walnutraisinbreaditem>],80);
@@ -1979,7 +1979,7 @@ RecipeBuilder.get("chef")
   .create();
 // Cream of avocado soup
 recipes.removeByRecipeName("harvestcraft:creamofavocadosoupitem");
-//stocke ExSartagine.addKettleRecipe([avocado,heavyCream,lime,spice,stock,<harvestcraft:vanillaitem>],cookKitKettle,null,[<harvestcraft:creamofavocadosoupitem>],80);
+ExSartagine.addKettleRecipe([avocado,heavyCream,lime,spice,stock,<harvestcraft:vanillaitem>],cookKitKettle,null,[<harvestcraft:creamofavocadosoupitem>],80);
 //Avocado burrito -&C
 recipes.removeByRecipeName("harvestcraft:avocadoburritoitem_listallporkcooked");
 recipes.removeByRecipeName("harvestcraft:avocadoburritoitem_listallchicken");
@@ -2066,13 +2066,13 @@ RecipeBuilder.get("chef")
   .create();
 // Cactus soup
 recipes.removeByRecipeName("harvestcraft:cactussoupitem");
-//stocke ExSartagine.addKettleRecipe([<ore:blockCactus>|<biomesoplenty:plant_1:6>,stock],null,null,[<harvestcraft:cactussoupitem>],80);
+ExSartagine.addKettleRecipe([<ore:blockCactus>|<biomesoplenty:plant_1:6>,stock],null,null,[<harvestcraft:cactussoupitem>],80);
 //Waffles
 recipes.removeByRecipeName("harvestcraft:wafflesitem");
 ExSartagine.addKettleRecipe([batter,milkBottle,butter],null,null,[<harvestcraft:wafflesitem>],80);
 //Seed soup
 recipes.removeByRecipeName("harvestcraft:seedsoupitem");
-//stocke ExSartagine.addKettleRecipe([seed,seed,seed,stock],null,null,[<harvestcraft:seedsoupitem>],80);
+ExSartagine.addKettleRecipe([seed,seed,seed,stock],null,null,[<harvestcraft:seedsoupitem>],80);
 //Soft pretzel
 recipes.removeByRecipeName("harvestcraft:softpretzelitem");
 ExSartagine.addKettleRecipe([dough,butter,salt],cookKitKettle,waterBottle,[<harvestcraft:softpretzelitem>],80);
@@ -2229,7 +2229,7 @@ RecipeBuilder.get("chef")
   .create();
 //Garden Soup
 recipes.remove(<harvestcraft:gardensoupitem>);
-//stocke ExSartagine.addKettleRecipe([stock,veggie,veggie],cookKitKettle,null,[<harvestcraft:gardensoupitem>],80);
+ExSartagine.addKettleRecipe([stock,veggie,veggie],cookKitKettle,null,[<harvestcraft:gardensoupitem>],80);
 //Jellies and their fruit-sandwich counter parts!
 var jellyFruitAndSandwich as IItemStack[string][string] = {
   apple: {
@@ -2432,7 +2432,7 @@ recipes.remove(<harvestcraft:gingerchickenitem>);
 ExSartagine.addKettleRecipe([rawChicken,ginger,scallion,honey],cookKitKettle,null,[<harvestcraft:gingerchickenitem>],80);
 //Old World Veggie Soup -&R
 recipes.remove(<harvestcraft:oldworldveggiesoupitem>);
-//stocke ExSartagine.addKettleRecipe([stewCondiment,stewCondiment,stock,barley],cookKitKettle,null,[<harvestcraft:oldworldveggiesoupitem>],80);
+ExSartagine.addKettleRecipe([stewCondiment,stewCondiment,stock,barley],cookKitKettle,null,[<harvestcraft:oldworldveggiesoupitem>],80);
 //Spice Bun
 recipes.remove(<harvestcraft:spicebunitem>);
 ExSartagine.addKettleRecipe([dough,milkBottle,groundNutmeg,groundCinnamon,<harvestcraft:raisinsitem>],cookKitKettle,null,[<harvestcraft:spicebunitem>],80);
@@ -2441,7 +2441,7 @@ recipes.remove(<harvestcraft:gingeredrhubarbtartitem>);
 ExSartagine.addKettleRecipe([dough,rhubarb,ginger,sugar,egg],cookKitKettle,null,[<harvestcraft:gingeredrhubarbtartitem>],80);
 //Lamb Barely Stew
 recipes.remove(<harvestcraft:lambbarleysoupitem>);
-//stocke ExSartagine.addKettleRecipe([stock,rawMutton,barley,stewCondiment,stewCondiment],cookKitKettle,null,[<harvestcraft:lambbarleysoupitem>],80);
+ExSartagine.addKettleRecipe([stock,rawMutton,barley,stewCondiment,stewCondiment],cookKitKettle,null,[<harvestcraft:lambbarleysoupitem>],80);
 //Honey Lemon Lamb
 recipes.remove(<harvestcraft:honeylemonlambitem>);
 ExSartagine.addKettleRecipe([honey,lemon,rawMutton,mustard],cookKitKettle,null,[<harvestcraft:honeylemonlambitem>],80);
@@ -2942,7 +2942,7 @@ recipes.remove(<harvestcraft:peaandhamsoupitem>);
 ExSartagine.addKettleRecipe([peas,rawPork,stewCondiment,stewCondiment,stewCondiment,pepper],cookKitKettle,null,[<harvestcraft:peaandhamsoupitem>],80);
 //Potato and Leek soup -&R
 recipes.remove(<harvestcraft:potatoandleeksoupitem>);
-//stocke ExSartagine.addKettleRecipe([potato,leek,stock,heavyCream,spice,pepper],cookKitKettle,null,[<harvestcraft:potatoandleeksoupitem>],80);
+ExSartagine.addKettleRecipe([potato,leek,stock,heavyCream,spice,pepper],cookKitKettle,null,[<harvestcraft:potatoandleeksoupitem>],80);
 //Yorkshire Pudding
 recipes.remove(<harvestcraft:yorkshirepuddingitem>);
 //stocke ExSartagine.addKettleRecipe([batter,salt,stock,milkBottle],cookKitKettle,null,[<harvestcraft:yorkshirepuddingitem>],80);
@@ -3255,7 +3255,7 @@ recipes.remove(<harvestcraft:steakfajitaitem>);
 ExSartagine.addKettleRecipe([rawBeef,veggie,veggie,chili,spice,tortilla],cookKitKettle,null,[<harvestcraft:steakfajitaitem>],80);
 //Ramen -&R
 recipes.remove(<harvestcraft:ramenitem>);
-//stocke ExSartagine.addKettleRecipe([noodles,stock,salt,<ore:stickWood>],null,null,[<harvestcraft:ramenitem>],80);
+//ExSartagine.addKettleRecipe([noodles,stock,salt,<ore:stickWood>],null,null,[<harvestcraft:ramenitem>],80);
 //Miso Soup -&R
 recipes.remove(<harvestcraft:misosoupitem>);
 ExSartagine.addKettleRecipe([firmTofu,scallion,misoPaste],null,waterBottle2,[<harvestcraft:misosoupitem>],80);
@@ -3407,7 +3407,7 @@ RecipeBuilder.get("chef")
   .create();
 //Pho
 recipes.remove(<harvestcraft:phoitem>);
-//stocke ExSartagine.addKettleRecipe([stock,noodles,spice,groundCinnamon,onion],null,null,[<harvestcraft:phoitem>],80);
+ExSartagine.addKettleRecipe([stock,noodles,spice,groundCinnamon,onion],null,null,[<harvestcraft:phoitem>],80);
 //Bubble Tea
 recipes.remove(<harvestcraft:bubbleteaitem>);
 ExSartagine.addKettleRecipe([flour,sugar,teaLeaf],null,waterBottle,[<harvestcraft:bubbleteaitem>],80);
@@ -3415,7 +3415,7 @@ ExSartagine.addKettleRecipe([flour,sugar,teaLeaf],null,waterBottle,[<harvestcraf
 
 //Wonton Soup
 recipes.remove(<harvestcraft:wontonsoupitem>);
-//stocke ExSartagine.addKettleRecipe([stock,dough,scallion,ginger,soySauce],null,null,[<harvestcraft:wontonsoupitem>],80);
+ExSartagine.addKettleRecipe([stock,dough,scallion,ginger,soySauce],null,null,[<harvestcraft:wontonsoupitem>],80);
 //Spring Rolls
 recipes.remove(<harvestcraft:springrollitem>);
 recipes.addShapeless("springroll", <harvestcraft:springrollitem>,[rice,hoisinSauce,peanut,veggie,lime,spice,lettuce,cookKitBad]);
@@ -3541,7 +3541,7 @@ recipes.remove(<harvestcraft:blackpaellaitem>);
 //stocke ExSartagine.addKettleRecipe([calamari/*gold*/,<minecraft:dye:0>,rice,stock,garlic,chili],null,null,[<harvestcraft:blackpaellaitem>],80);
 //Blazing Soup
 recipes.remove(<harvestcraft:blazingsoupitem>);
-//stocke ExSartagine.addKettleRecipe([stock,<minecraft:blaze_powder>,<minecraft:nether_wart>],null,null,[<harvestcraft:blazingsoupitem>],80);
+//ExSartagine.addKettleRecipe([stock,<minecraft:blaze_powder>,<minecraft:nether_wart>],null,null,[<harvestcraft:blazingsoupitem>],80);
 //Brioche Bun
 recipes.remove(<harvestcraft:briochebunitem>);
 ExSartagine.addKettleRecipe([flour,egg,butter,milkBottle,heavyCream,sugar],cookKitKettle,waterBottle,[<harvestcraft:briochebunitem>],80);

--- a/scripts/ex_sartagine.zs
+++ b/scripts/ex_sartagine.zs
@@ -433,8 +433,8 @@ val cakeBatter = <betterwithmods:raw_pastry>;
 // Stock Recipes
 recipes.remove(stock);
 ExSartagine.addPotRecipe(<minecraft:bone>|<undergroundbiomes:fossil_piece:2>|<undergroundbiomes:fossil_piece:3>|<undergroundbiomes:fossil_piece:5>|<undergroundbiomes:fossil_piece:7>, stock);
-ExSartagine.addPotRecipe(veggie, stock*2);
-ExSartagine.addPotRecipe(<ore:listAllmeatraw>|<betterwithaddons:congealed>, stock*3);
+ExSartagine.addKettleRecipe([veggie], null, null, [stock*2], 80);
+ExSartagine.addKettleRecipe([<ore:listAllmeatraw>|<betterwithaddons:congealed>], null, null, [stock*3], 80);
 
 // Wormhole Potion
 ExSartagine.addKettleRecipe([<quark:arrow_ender>,<minecraft:glass_bottle>],null,waterBottle,[<bountifulbaubles:potionwormhole>],300);


### PR DESCRIPTION
I've been playing for the last few weeks and noticed all the recipes for stock and most of stock-using soup recipes were removed, This PR adds them back in

Some stock recipes still exist, but can't be crafted since stock was removed (onion soup, meat pie, etc.) so I wanted to call attention to that to remove them all the way or to add these recipes back in.